### PR TITLE
Store and restore window sizes and positions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,6 +1789,11 @@
         "touch": "0.0.3"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2172,6 +2177,16 @@
             "camelcase": "^4.1.0"
           }
         }
+      }
+    },
+    "electron-window-state": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.1.tgz",
+      "integrity": "sha512-9NE2mB8ZM9IZpVexdBVNbJLXkBByTZYArHMuwtA04U5R3ajl6IE82v3UkmSuf0hWczP0+is/4vLIqNkJwdvCrQ==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "jsonfile": "^4.0.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "encodeurl": {
@@ -3864,8 +3879,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "gulp": {
       "version": "4.0.0",
@@ -5137,7 +5151,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -5771,7 +5784,6 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -5779,8 +5791,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "about-window": "^1.12.1",
+    "electron-window-state": "^5.0.1",
     "jquery": "^3.3.1"
   }
 }

--- a/src/javascripts/mainwindow.js
+++ b/src/javascripts/mainwindow.js
@@ -1,5 +1,6 @@
-const { app, BrowserWindow} = require('electron')
+const electron = require('electron')
 const url = require('url')
+const windowState = require('electron-window-state')
 // const log = require('electron-log');
 
 var encode_search = (json) => {
@@ -7,10 +8,18 @@ var encode_search = (json) => {
 }
 
 var createMainWindow = () => {
+  const workAreaSize = electron.screen.getPrimaryDisplay().workAreaSize
+  // Load the previous state with fall-back to defaults
+  const mainWindowState = windowState({
+    defaultWidth: workAreaSize.width - 200,
+    defaultHeight: workAreaSize.height - 100,
+  })
   // Create the browser window.
-  win = new BrowserWindow({
-    width: 1300,
-    height: 900,
+  win = new electron.BrowserWindow({
+    x: mainWindowState.x,
+    y: mainWindowState.y,
+    width: mainWindowState.width,
+    height: mainWindowState.height,
     titleBarStyle: 'hidden',
     minWidth: 300,
     minHeight: 300,
@@ -18,13 +27,20 @@ var createMainWindow = () => {
     show: false
   })
 
+  /**
+   * Let us register listeners on the window, so we can update the state
+   * automatically (the listeners will be removed when the window is closed)
+   * and restore the maximized or full screen state
+   */
+  mainWindowState.manage(win)
+
   windowSettings = {
     'url': 'https://drive.google.com/drive/'
   }
 
   var file_url = url.format({
     protocol: 'file',
-    pathname: `${app.getAppPath()}/build/templates/index.html`,
+    pathname: `${electron.app.getAppPath()}/build/templates/index.html`,
     slashes: true,
     search: encode_search(windowSettings)
   })


### PR DESCRIPTION
Add the `electron-window-state` package which allows to store and restore window sizes and positions.

Also changed the initial default size to be a little bit smaller than the current user display instead of a fixed value of 1300x900